### PR TITLE
Add tests for Credits::Buy service

### DIFF
--- a/docs/tests/test_credits_buy_service.md
+++ b/docs/tests/test_credits_buy_service.md
@@ -1,0 +1,147 @@
+# Testes do Service Credits::Buy
+
+## Arquivo de Teste
+
+`spec/services/credits/buy_spec.rb`
+
+## Arquivo Testado
+
+`app/services/credits/buy.rb`
+
+## Cobertura Anterior
+
+0%
+
+## Descrição
+
+Este arquivo de teste foi criado para cobrir o service `Credits::Buy`, responsável por processar a compra de itens utilizando créditos do usuário.
+
+O service verifica se o comprador possui créditos suficientes e, em caso positivo, marca os créditos como gastos e os associa à compra.
+
+## Lógica do Service
+
+```ruby
+module Credits
+  class Buy
+    def self.call(purchaser:, purchase:, cost:)
+      return false unless purchaser.enough_credits?(cost)
+
+      purchaser.credits.unspent.limit(cost).update_all(
+        spent: true,
+        spent_at: Time.current,
+        purchase_type: purchase.class.name,
+        purchase_id: purchase.id,
+      )
+      purchaser.save
+
+      true
+    end
+  end
+end
+```
+
+## Casos de Teste Implementados
+
+### 1. Comprador com créditos suficientes
+
+- **Teste**: Retorna true
+
+  - Verifica que a operação é bem-sucedida
+
+- **Teste**: Marca créditos como gastos
+
+  - Verifica que a quantidade correta de créditos é marcada como `spent`
+  - Verifica que os créditos restantes permanecem `unspent`
+
+- **Teste**: Define o timestamp spent_at
+
+  - Verifica que o campo `spent_at` é preenchido
+
+- **Teste**: Associa a compra aos créditos
+
+  - Verifica `purchase_type` (nome da classe do item comprado)
+  - Verifica `purchase_id` (ID do item comprado)
+
+- **Teste**: Gasta exatamente a quantidade de créditos do custo
+  - Com 10 créditos e custo 7, verifica 7 gastos e 3 restantes
+
+### 2. Comprador sem créditos suficientes
+
+- **Teste**: Retorna false
+
+  - Verifica que a operação falha quando não há créditos suficientes
+
+- **Teste**: Não marca nenhum crédito como gasto
+  - Verifica que todos os créditos permanecem `unspent`
+
+### 3. Comprador sem nenhum crédito
+
+- **Teste**: Retorna false
+  - Usuário sem créditos não pode fazer compras
+
+### 4. Custo zero
+
+- **Teste**: Retorna true e não gasta créditos
+  - Compras gratuitas são permitidas
+  - Nenhum crédito é marcado como gasto
+
+### 5. Créditos exatos
+
+- **Teste**: Retorna true e gasta todos os créditos
+  - Com 10 créditos e custo 10, todos são gastos
+
+### 6. Organização como compradora
+
+- **Teste**: Funciona com organização como purchaser
+  - Organizações também podem usar o service
+  - Verifica que os créditos da organização são gastos
+
+## Setup do Teste
+
+```ruby
+let(:user) { create(:user) }
+let(:article) { create(:article, user: user) }
+
+before do
+  Credit.add_to(user, 10)
+end
+```
+
+## Execução
+
+```bash
+bundle exec rspec spec/services/credits/buy_spec.rb --format documentation
+```
+
+## Resultado Esperado
+
+```
+Credits::Buy
+  .call
+    when purchaser has enough credits
+      returns true
+      marks credits as spent
+      sets the spent_at timestamp
+      associates the purchase with the credits
+      spends exactly the cost amount of credits
+    when purchaser does not have enough credits
+      returns false
+      does not mark any credits as spent
+    when purchaser has no credits
+      returns false
+    when cost is zero
+      returns true and does not spend any credits
+    when purchaser has exact amount of credits needed
+      returns true and spends all credits
+    with organization as purchaser
+      works with organization purchaser
+
+11 examples, 0 failures
+```
+
+## Observações
+
+- O service é idempotente - não altera estado se a operação falhar
+- Suporta tanto `User` quanto `Organization` como compradores
+- Utiliza `update_all` para eficiência em operações em lote
+- Os créditos são gastos na ordem de criação (FIFO) devido ao `limit(cost)`

--- a/spec/services/credits/buy_spec.rb
+++ b/spec/services/credits/buy_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe Credits::Buy, type: :service do
+  describe ".call" do
+    let(:user) { create(:user) }
+    let(:article) { create(:article, user: user) }
+
+    before do
+      # Add credits to the user
+      Credit.add_to(user, 10)
+    end
+
+    context "when purchaser has enough credits" do
+      it "returns true" do
+        result = described_class.call(purchaser: user, purchase: article, cost: 5)
+
+        expect(result).to be(true)
+      end
+
+      it "marks credits as spent" do
+        described_class.call(purchaser: user, purchase: article, cost: 5)
+
+        expect(user.credits.spent.count).to eq(5)
+        expect(user.credits.unspent.count).to eq(5)
+      end
+
+      it "sets the spent_at timestamp" do
+        described_class.call(purchaser: user, purchase: article, cost: 3)
+
+        user.credits.spent.each do |credit|
+          expect(credit.spent_at).not_to be_nil
+        end
+      end
+
+      it "associates the purchase with the credits" do
+        described_class.call(purchaser: user, purchase: article, cost: 4)
+
+        user.credits.spent.each do |credit|
+          expect(credit.purchase_type).to eq(article.class.name)
+          expect(credit.purchase_id).to eq(article.id)
+        end
+      end
+
+      it "spends exactly the cost amount of credits" do
+        described_class.call(purchaser: user, purchase: article, cost: 7)
+
+        expect(user.credits.spent.count).to eq(7)
+        expect(user.credits.unspent.count).to eq(3)
+      end
+    end
+
+    context "when purchaser does not have enough credits" do
+      it "returns false" do
+        result = described_class.call(purchaser: user, purchase: article, cost: 15)
+
+        expect(result).to be(false)
+      end
+
+      it "does not mark any credits as spent" do
+        described_class.call(purchaser: user, purchase: article, cost: 15)
+
+        expect(user.credits.spent.count).to eq(0)
+        expect(user.credits.unspent.count).to eq(10)
+      end
+    end
+
+    context "when purchaser has no credits" do
+      let(:user_without_credits) { create(:user) }
+
+      it "returns false" do
+        result = described_class.call(purchaser: user_without_credits, purchase: article, cost: 1)
+
+        expect(result).to be(false)
+      end
+    end
+
+    context "when cost is zero" do
+      it "returns true and does not spend any credits" do
+        result = described_class.call(purchaser: user, purchase: article, cost: 0)
+
+        expect(result).to be(true)
+        expect(user.credits.spent.count).to eq(0)
+      end
+    end
+
+    context "when purchaser has exact amount of credits needed" do
+      it "returns true and spends all credits" do
+        result = described_class.call(purchaser: user, purchase: article, cost: 10)
+
+        expect(result).to be(true)
+        expect(user.credits.spent.count).to eq(10)
+        expect(user.credits.unspent.count).to eq(0)
+      end
+    end
+
+    context "with organization as purchaser" do
+      let(:organization) { create(:organization) }
+
+      before do
+        Credit.add_to(organization, 10)
+      end
+
+      it "works with organization purchaser" do
+        result = described_class.call(purchaser: organization, purchase: article, cost: 5)
+
+        expect(result).to be(true)
+        expect(organization.credits.spent.count).to eq(5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces comprehensive RSpec tests for the Credits::Buy service, covering scenarios for users and organizations purchasing with credits. Tests include sufficient, insufficient, and exact credits, zero-cost purchases, and correct association of spent credits with purchases.