### PR TITLE
Update initScrolling.js

### DIFF
--- a/app/assets/javascripts/initializers/initScrolling.js
+++ b/app/assets/javascripts/initializers/initScrolling.js
@@ -30,7 +30,7 @@ function fetchNext(el, endpoint, insertCallback, suffix) {
   }
 
   var fetchUrl =
-    `${endpoint}?page=${nextPage}&${urlParams}${suffix}&signature=${parseInt(
+    `${endpoint}?page=${nextPage}&${urlParams}${suffix}&signature=${Number.parseInt(
       Date.now() / 400000,
       10,
     )}`.replace('&&', '&');


### PR DESCRIPTION
Aplicando recomendação do SonarCloud de chamar o método parseInt por Number.parseInt ao invés de parseInt apenas, de forma a completar a issue #16 .

Link para a recomendação do SonarCloud: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=conde-vampiresco-espectral-trevoso_ES2_2025-2_forem&open=AZq4ZpQVGp2JzAxoAZhA